### PR TITLE
Feat/#32 API 문서 작성 방식을 변경합니다. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,5 @@ replay_pid*
 ./gradle
 /out
 /secret
-/.gradle
+/.gradle/
 /.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -9,10 +9,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.1'
     id 'io.spring.dependency-management' version '1.1.5'
-
-    id 'com.epages.restdocs-api-spec' version '0.18.4'
     id 'org.hidetake.swagger.generator' version '2.18.2'
-
 }
 
 group = 'com.donkeys_today'
@@ -57,73 +54,23 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.2.1'
 
     //Api
-    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-    testImplementation 'com.epages:restdocs-api-spec-mockmvc:'+ restdocsApiSpecVersion
-    implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
     testImplementation 'io.rest-assured:spring-mock-mvc:5.4.0'
     testImplementation "io.rest-assured:json-path:5.4.0"
     testImplementation "io.rest-assured:xml-path:5.4.0"
-    swaggerUI 'org.webjars:swagger-ui:4.11.1'
 
     //actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-
-
 }
 
 tasks.named('test') {
     useJUnitPlatform()
 }
 
-swaggerSources {
-    sample{
-        setInputFile(file("${project.buildDir}/api-spec/openapi3.yaml"))
-    }
-}
-
-openapi3{
-    setServer("http://localhost:8080")
-    title = "API 문서"
-    description = "RestDocsWithSwaggerDocs"
-    version = "0.0.1"
-    format = "yaml"
-}
-
-//API 문서 AuthHeader 용
-tasks.withType(GenerateSwaggerUI).configureEach {
-    dependsOn 'openapi3'
-    doFirst {
-        def swaggerUIFile = file("${openapi3.outputDirectory}/openapi3.yaml")
-        def securitySchemesContent ="  securitySchemes:\n" +  \
-                                      "    APIKey:\n" +  \
-                                      "      type: apiKey\n" +  \
-                                      "      name: Authorization\n" +  \
-                                      "      in: header\n" + \
-                                      "security:\n" +
-                                        "  - APIKey: []  # Apply the security scheme here"
-        swaggerUIFile.append securitySchemesContent
-    }
-}
-
-// 태스크 순서 재정의
-tasks.named('generateSwaggerUISample') {
-    mustRunAfter 'test'
-    mustRunAfter 'processResources'
-}
-
-//정적 파일 호스팅을 위한 파일 복사
-task copyDocument(type: Copy) {
-    dependsOn 'generateSwaggerUISample'
-    from file("build/swagger-ui-sample")
-    into file("src/main/resources/static/docs")
-}
-
 //Jar 로 빌드
 bootJar{
-    dependsOn processResources
-    from("${generateSwaggerUISample.outputDir}"){
-        into 'static/docs'
-    }
+
 }
 
 //Feign

--- a/src/main/java/com/donkeys_today/server/presentation/api/UserController.java
+++ b/src/main/java/com/donkeys_today/server/presentation/api/UserController.java
@@ -8,11 +8,12 @@ import com.donkeys_today.server.presentation.user.dto.response.UserSignUpRespons
 import com.donkeys_today.server.support.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,15 +26,23 @@ public interface UserController {
   @Operation(summary = "유저 회원가입 ", description = "Authorization code 와 UserSignUpRequest 로 회원가입을 진행합니다.")
   @PostMapping("/auth/signup")
   ResponseEntity<ApiResponse<UserSignUpResponse>> signUp(
-      @RequestHeader(Constants.AUTHORIZATION) @Parameter(name = "auth_code", description = "클라이언트가 인증 서버로부터 받은 인증 코드", required = true) final String auth_code,
-      @RequestBody @Parameter(name = "UserSignUpRequest", description = "회원가입을 위하여 부가적으로 받는 정보 객체", schema = @Schema(contains = UserSignUpRequest.class)) final UserSignUpRequest request
+      @RequestHeader(Constants.AUTHORIZATION) @Parameter(name = "Authorization", description = "클라이언트가 인증 서버로부터 받은 인증 코드", required = true) final String auth_code,
+      @RequestBody(
+          description = "회원가입을 위하여 부가적으로 받는 정보 객체",
+          required = true,
+          content = @Content(schema = @Schema(implementation = UserSignUpRequest.class))
+      ) final UserSignUpRequest request
   );
 
   @Operation(summary = "유저 로그인 ", description = "Authorization code로 로그인을 진행합니다.")
   @PostMapping("/auth/signin")
   ResponseEntity<ApiResponse<UserSignInResponse>> signIn(
-      @RequestHeader @Parameter(name = "auth_code", description = "클라이언트가 인증 서버로부터 받은 인증 코드", required = true) final String auth_code,
-      @RequestBody @Parameter(name = "UserSignInRequest", description = "로그인을 위하여 부가적으로 받는 정보 객체", schema = @Schema(contains = UserSignInRequest.class))final UserSignInRequest userSignInRequest
+      @RequestHeader(Constants.AUTHORIZATION) @Parameter(name = "Authorization", description = "클라이언트가 인증 서버로부터 받은 인증 코드", required = true) final String auth_code,
+      @RequestBody(
+          description = "로그인을 위하여 부가적으로 받는 정보 객체",
+          required = true,
+          content = @Content(schema = @Schema(implementation = UserSignInRequest.class))
+      ) final UserSignInRequest userSignInRequest
   );
 
 

--- a/src/main/java/com/donkeys_today/server/presentation/api/UserController.java
+++ b/src/main/java/com/donkeys_today/server/presentation/api/UserController.java
@@ -1,0 +1,40 @@
+package com.donkeys_today.server.presentation.api;
+
+import com.donkeys_today.server.common.constants.Constants;
+import com.donkeys_today.server.presentation.user.dto.requset.UserSignInRequest;
+import com.donkeys_today.server.presentation.user.dto.requset.UserSignUpRequest;
+import com.donkeys_today.server.presentation.user.dto.response.UserSignInResponse;
+import com.donkeys_today.server.presentation.user.dto.response.UserSignUpResponse;
+import com.donkeys_today.server.support.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "인증/인가")
+@RequestMapping("/api/v1")
+@RestController
+public interface UserController {
+
+  @Operation(summary = "유저 회원가입 ", description = "Authorization code 와 UserSignUpRequest 로 회원가입을 진행합니다.")
+  @PostMapping("/auth/signup")
+  ResponseEntity<ApiResponse<UserSignUpResponse>> signUp(
+      @RequestHeader(Constants.AUTHORIZATION) @Parameter(name = "auth_code", description = "클라이언트가 인증 서버로부터 받은 인증 코드", required = true) final String auth_code,
+      @RequestBody @Parameter(name = "UserSignUpRequest", description = "회원가입을 위하여 부가적으로 받는 정보 객체", schema = @Schema(contains = UserSignUpRequest.class)) final UserSignUpRequest request
+  );
+
+  @Operation(summary = "유저 로그인 ", description = "Authorization code로 로그인을 진행합니다.")
+  @PostMapping("/auth/signin")
+  ResponseEntity<ApiResponse<UserSignInResponse>> signIn(
+      @RequestHeader @Parameter(name = "auth_code", description = "클라이언트가 인증 서버로부터 받은 인증 코드", required = true) final String auth_code,
+      @RequestBody @Parameter(name = "UserSignInRequest", description = "로그인을 위하여 부가적으로 받는 정보 객체", schema = @Schema(contains = UserSignInRequest.class))final UserSignInRequest userSignInRequest
+  );
+
+
+}

--- a/src/main/java/com/donkeys_today/server/presentation/user/UserControllerImpl.java
+++ b/src/main/java/com/donkeys_today/server/presentation/user/UserControllerImpl.java
@@ -2,6 +2,7 @@ package com.donkeys_today.server.presentation.user;
 
 import com.donkeys_today.server.application.user.UserService;
 import com.donkeys_today.server.common.constants.Constants;
+import com.donkeys_today.server.presentation.api.UserController;
 import com.donkeys_today.server.presentation.user.dto.requset.UserSignInRequest;
 import com.donkeys_today.server.presentation.user.dto.requset.UserSignUpRequest;
 import com.donkeys_today.server.presentation.user.dto.response.UserSignInResponse;
@@ -15,18 +16,18 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
-public class UserController {
+public class UserControllerImpl implements UserController {
 
   private final UserService userService;
 
   @PostMapping("/auth/signup")
-  public ResponseEntity<ApiResponse<?>> signUp(
+  @Override
+  public ResponseEntity<ApiResponse<UserSignUpResponse>> signUp(
       @RequestHeader(Constants.AUTHORIZATION) final String authorization_code,
       @RequestBody final UserSignUpRequest userSignUpRequest) {
     final UserSignUpResponse response = userService.signUp(authorization_code,userSignUpRequest);
@@ -34,9 +35,9 @@ public class UserController {
         .body(ApiResponse.success(SuccessType.CREATED_SUCCESS, response));
   }
 
-  @ResponseBody
+  @Override
   @PostMapping("/auth/signin")
-  public ResponseEntity<?> signIn(@RequestHeader(Constants.AUTHORIZATION) String code,
+  public ResponseEntity<ApiResponse<UserSignInResponse>> signIn(@RequestHeader(Constants.AUTHORIZATION) String code,
       @RequestBody final UserSignInRequest userSignInRequest) {
     System.out.println(code);
     final UserSignInResponse response = userService.signIn(code,userSignInRequest);

--- a/src/main/java/com/donkeys_today/server/presentation/user/dto/requset/UserSignInRequest.java
+++ b/src/main/java/com/donkeys_today/server/presentation/user/dto/requset/UserSignInRequest.java
@@ -1,6 +1,9 @@
 package com.donkeys_today.server.presentation.user.dto.requset;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record UserSignInRequest(
+    @Schema(description = "플랫폼", example = "apple/kakao")
     String platform
 ) {
 

--- a/src/main/java/com/donkeys_today/server/presentation/user/dto/requset/UserSignUpRequest.java
+++ b/src/main/java/com/donkeys_today/server/presentation/user/dto/requset/UserSignUpRequest.java
@@ -1,8 +1,10 @@
 package com.donkeys_today.server.presentation.user.dto.requset;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalTime;
 
 public record UserSignUpRequest(
+    @Schema(description = "로그인 플랫폼", example = "apple/kakao")
     String platform,
     boolean alarmAgreement,
     LocalTime alarmTime

--- a/src/main/java/com/donkeys_today/server/support/security/config/WhiteListConstants.java
+++ b/src/main/java/com/donkeys_today/server/support/security/config/WhiteListConstants.java
@@ -11,9 +11,9 @@ public class WhiteListConstants {
             "/oauth/authorize",
             "/actuator/health",
             "/error",
-            "/swagger-ui/",
-            "/swagger-resources/",
-            "/api-docs/"
+            "/swagger",
+            "/swagger-ui/**",
+            "/api-docs/**"
     );
 
     public static final String[] SECURITY_WHITE_LIST = {
@@ -21,9 +21,11 @@ public class WhiteListConstants {
             "/api/v1/auth/**",
             "/",
             "/actuator/health",
-            "/api-docs/**",
-            "swagger-ui/**",
+            "/swagger",
+            "/swagger-ui/**",
             "/redirect",
             "/login/oauth2/code/kakao",
+            "/v3/api-docs/**",
+
     };
 }

--- a/src/main/java/com/donkeys_today/server/support/swagger/config/SwaggerConfig.java
+++ b/src/main/java/com/donkeys_today/server/support/swagger/config/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package com.donkeys_today.server.support.swagger.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI customOpenAPI(){
+      String jwt = "JWT";
+      SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
+      Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
+          .name(jwt)
+          .type(SecurityScheme.Type.HTTP)
+          .scheme("bearer")
+          .bearerFormat("JWT")
+      );
+    return new OpenAPI()
+        .components(new Components())
+        .info(apiInfo());
+  }
+
+  private Info apiInfo(){
+    return new Info()
+        .title("Clody API 문서")
+        .description("Clody API ")
+        .version("1.0");
+  }
+}

--- a/src/test/java/com/donkeys_today/server/docs/RestDocsSupport.java
+++ b/src/test/java/com/donkeys_today/server/docs/RestDocsSupport.java
@@ -1,29 +1,29 @@
-package com.donkeys_today.server.docs;
-
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.restassured.module.mockmvc.RestAssuredMockMvc;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-
-@ExtendWith(RestDocumentationExtension.class)
-public abstract class RestDocsSupport {
-
-  protected MockMvc mockMvc;
-  protected ObjectMapper objectMapper = new ObjectMapper();
-
-  @BeforeEach
-  public void setUp(RestDocumentationContextProvider provider) throws Exception {
-    this.mockMvc = MockMvcBuilders.standaloneSetup(initController())
-        .apply(documentationConfiguration(provider))
-        .build();
-    RestAssuredMockMvc.mockMvc(this.mockMvc);
-  }
-
-  protected abstract Object initController() throws Exception;
-}
+//package com.donkeys_today.server.docs;
+//
+//import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+//
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import io.restassured.module.mockmvc.RestAssuredMockMvc;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.springframework.restdocs.RestDocumentationContextProvider;
+//import org.springframework.restdocs.RestDocumentationExtension;
+//import org.springframework.test.web.servlet.MockMvc;
+//import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+//
+//@ExtendWith(RestDocumentationExtension.class)
+//public abstract class RestDocsSupport {
+//
+//  protected MockMvc mockMvc;
+//  protected ObjectMapper objectMapper = new ObjectMapper();
+//
+//  @BeforeEach
+//  public void setUp(RestDocumentationContextProvider provider) throws Exception {
+//    this.mockMvc = MockMvcBuilders.standaloneSetup(initController())
+//        .apply(documentationConfiguration(provider))
+//        .build();
+//    RestAssuredMockMvc.mockMvc(this.mockMvc);
+//  }
+//
+//  protected abstract Object initController() throws Exception;
+//}

--- a/src/test/java/com/donkeys_today/server/docs/user/UserControllerDocsTest.java
+++ b/src/test/java/com/donkeys_today/server/docs/user/UserControllerDocsTest.java
@@ -1,110 +1,110 @@
-
-package com.donkeys_today.server.docs.user;
-
-import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatTypes.NUMBER;
-import static com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatTypes.STRING;
-import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.mock;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-
-import com.donkeys_today.server.application.user.UserService;
-import com.donkeys_today.server.application.user.dto.request.UserSignUpRequest;
-import com.donkeys_today.server.application.user.dto.response.UserResponse;
-import com.donkeys_today.server.application.user.dto.response.UserSignUpResponse;
-import com.donkeys_today.server.docs.RestDocsSupport;
-import com.donkeys_today.server.presentation.user.UserController;
-import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.epages.restdocs.apispec.Schema;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-public class UserControllerDocsTest extends RestDocsSupport {
-
-  private final UserService userService = mock(UserService.class);
-
-  @Override
-  protected Object initController() throws Exception {
-    return new UserController(userService);
-  }
-
-  @DisplayName("User 조회 API Test")
-  @Test
-  void 유저_조회_테스트() throws Exception {
-
-    var 유저_요청_응답 = new UserResponse(1L, "홍길동", "010-9090-9090", "rkd@gm.com");
-
-    given(userService.getUser(anyLong())).willReturn(유저_요청_응답);
-
-    given()
-        .param("id", "1")
-        .when()
-        .get("http://localhost:8080/api/v1/user")
-        .then()
-        .statusCode(200)
-        .and()
-        .apply(document("findUser",
-            preprocessRequest(prettyPrint()),
-            preprocessResponse(prettyPrint()),
-            resource(ResourceSnippetParameters.builder()
-                .tag("User API")
-                .summary("유저 관련 API")
-                .queryParameters(
-                    parameterWithName("id").description("유저 ID")
-                ).responseFields(
-                    fieldWithPath("status").type(NUMBER).description("상태 코드"),
-                    fieldWithPath("message").type(STRING).description("상태 메세지"),
-                    fieldWithPath("data.id").type(NUMBER).description("유저 ID"),
-                    fieldWithPath("data.userName").type(STRING).description("사용자 이름"),
-                    fieldWithPath("data.phoneNum").type(STRING).description("사용자 전화번호"),
-                    fieldWithPath("data.email").type(STRING).description("사용자 이메일"))
-                .responseSchema(Schema.schema("UserResponse"))
-                .build()
-            )));
-
-  }
-  @Test
-  public void 유저_생성_테스트(){
-    var 유저_가입_요청 = new UserSignUpRequest("홍길동", "010-9090-9090", "rkd@gm.com");
-    var 유저_가입_응답 = new UserSignUpResponse(1L, "홍길동", "010-9090-9090", "rkd@gm.com");
-
-    given(userService.signUp(any(UserSignUpRequest.class))).willReturn(유저_가입_응답);
-
-    given()
-        .body(유저_가입_요청)
-        .contentType("application/json")
-        .when()
-        .post("http://localhost:8080/api/v1/user/signUp")
-        .then()
-        .statusCode(201)
-        .and()
-        .apply(document("signUpUser",
-            preprocessRequest(prettyPrint()),
-            preprocessResponse(prettyPrint()),
-            resource(ResourceSnippetParameters.builder()
-                .tag("User API")
-                .summary("유저 관련 API")
-                    .requestFields(
-                        fieldWithPath("userName").type(STRING).description("사용자 이름"),
-                        fieldWithPath("phoneNum").type(STRING).description("전화번호"),
-                        fieldWithPath("email").type(STRING).description("이메일")
-                    ).responseFields(
-                        fieldWithPath("status").type(NUMBER).description("상태 코드"),
-                        fieldWithPath("message").type(STRING).description("상태 메세지"),
-                        fieldWithPath("data.id").type(NUMBER).description("유저 ID"),
-                        fieldWithPath("data.userName").type(STRING).description("사용자 이름"),
-                        fieldWithPath("data.phoneNum").type(STRING).description("전화번호"),
-                        fieldWithPath("data.email").type(STRING).description("이메일"))
-                    .responseSchema(Schema.schema("UserSignUpResponse"))
-                    .build()
-                )));
-  }
-}
+//
+//package com.donkeys_today.server.docs.user;
+//
+//import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+//import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+//import static com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatTypes.NUMBER;
+//import static com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatTypes.STRING;
+//import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.ArgumentMatchers.anyLong;
+//import static org.mockito.Mockito.mock;
+//import static org.mockito.BDDMockito.given;
+//import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+//import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+//import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+//import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+//import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+//
+//import com.donkeys_today.server.application.user.UserService;
+//import com.donkeys_today.server.application.user.dto.request.UserSignUpRequest;
+//import com.donkeys_today.server.application.user.dto.response.UserResponse;
+//import com.donkeys_today.server.application.user.dto.response.UserSignUpResponse;
+//import com.donkeys_today.server.docs.RestDocsSupport;
+//import com.donkeys_today.server.presentation.user.UserController;
+//import com.epages.restdocs.apispec.ResourceSnippetParameters;
+//import com.epages.restdocs.apispec.Schema;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//
+//public class UserControllerDocsTest extends RestDocsSupport {
+//
+//  private final UserService userService = mock(UserService.class);
+//
+//  @Override
+//  protected Object initController() throws Exception {
+//    return new UserController(userService);
+//  }
+//
+//  @DisplayName("User 조회 API Test")
+//  @Test
+//  void 유저_조회_테스트() throws Exception {
+//
+//    var 유저_요청_응답 = new UserResponse(1L, "홍길동", "010-9090-9090", "rkd@gm.com");
+//
+//    given(userService.getUser(anyLong())).willReturn(유저_요청_응답);
+//
+//    given()
+//        .param("id", "1")
+//        .when()
+//        .get("http://localhost:8080/api/v1/user")
+//        .then()
+//        .statusCode(200)
+//        .and()
+//        .apply(document("findUser",
+//            preprocessRequest(prettyPrint()),
+//            preprocessResponse(prettyPrint()),
+//            resource(ResourceSnippetParameters.builder()
+//                .tag("User API")
+//                .summary("유저 관련 API")
+//                .queryParameters(
+//                    parameterWithName("id").description("유저 ID")
+//                ).responseFields(
+//                    fieldWithPath("status").type(NUMBER).description("상태 코드"),
+//                    fieldWithPath("message").type(STRING).description("상태 메세지"),
+//                    fieldWithPath("data.id").type(NUMBER).description("유저 ID"),
+//                    fieldWithPath("data.userName").type(STRING).description("사용자 이름"),
+//                    fieldWithPath("data.phoneNum").type(STRING).description("사용자 전화번호"),
+//                    fieldWithPath("data.email").type(STRING).description("사용자 이메일"))
+//                .responseSchema(Schema.schema("UserResponse"))
+//                .build()
+//            )));
+//
+//  }
+//  @Test
+//  public void 유저_생성_테스트(){
+//    var 유저_가입_요청 = new UserSignUpRequest("홍길동", "010-9090-9090", "rkd@gm.com");
+//    var 유저_가입_응답 = new UserSignUpResponse(1L, "홍길동", "010-9090-9090", "rkd@gm.com");
+//
+//    given(userService.signUp(any(UserSignUpRequest.class))).willReturn(유저_가입_응답);
+//
+//    given()
+//        .body(유저_가입_요청)
+//        .contentType("application/json")
+//        .when()
+//        .post("http://localhost:8080/api/v1/user/signUp")
+//        .then()
+//        .statusCode(201)
+//        .and()
+//        .apply(document("signUpUser",
+//            preprocessRequest(prettyPrint()),
+//            preprocessResponse(prettyPrint()),
+//            resource(ResourceSnippetParameters.builder()
+//                .tag("User API")
+//                .summary("유저 관련 API")
+//                    .requestFields(
+//                        fieldWithPath("userName").type(STRING).description("사용자 이름"),
+//                        fieldWithPath("phoneNum").type(STRING).description("전화번호"),
+//                        fieldWithPath("email").type(STRING).description("이메일")
+//                    ).responseFields(
+//                        fieldWithPath("status").type(NUMBER).description("상태 코드"),
+//                        fieldWithPath("message").type(STRING).description("상태 메세지"),
+//                        fieldWithPath("data.id").type(NUMBER).description("유저 ID"),
+//                        fieldWithPath("data.userName").type(STRING).description("사용자 이름"),
+//                        fieldWithPath("data.phoneNum").type(STRING).description("전화번호"),
+//                        fieldWithPath("data.email").type(STRING).description("이메일"))
+//                    .responseSchema(Schema.schema("UserSignUpResponse"))
+//                    .build()
+//                )));
+//  }
+//}


### PR DESCRIPTION
## 📣 Related Issue

- #32

## 📝 Summary
기존 Swagger  + RestDocs 방식을 사용했지만, 코드의 복잡성이 증가하는 관계로
기존 Swagger를 사용하되, API용 인터페이스를 분리하여 코드 가독성을 해치지 않도록 분리했습니다. 


## 🙏 Question & PR point
Api 패키지에 기존 Swagger작성법처럼 작성하시면 됩니다. 
https://URL/swagger 로 접근하면 됩니다.
